### PR TITLE
chore: Add examples and usage section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To format ADF documents you need
 import { ADFEntity, formatAdf, markdownFormatter } from '../src';
 
 const adf : ADFEntity = { /* see full representation below */ }
-const markdown = renderAdf(adf, markdownFormatter)
+const markdown = formatAdf(adf, markdownFormatter)
 ```
 
 The example above will produce the following markdown given the ADF below.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ application running in the browser.
 ## 🎨 Design Goals
 
 * Make it trivial to render ADF documents into arbitrary formats.
-* Small runtime size: `simple-adf-formatter`'s size is `< 10kB`. Atlassian's [adf-utils](https://www.npmjs.com/package/@atlaskit/adf-utils) weighs > 550kB.
+* Small runtime size: `simple-adf-formatter`'s size is `< 2kB`. Atlassian's [adf-utils](https://www.npmjs.com/package/@atlaskit/adf-utils) weighs > 550kB.
 * No external dependencies: `simple-adf-formatter` has no external dependencies.
   Atlassian libraries bundle `@babel/runtime` and additional proprietary
   libraries from Atlassian.
@@ -36,9 +36,488 @@ application running in the browser.
 
 ## 📖 Usage
 
+To format ADF documents you need
+
+* the ADF object of type `ADFEntity`
+* a formatter implementation of type `Formatter<T>` with `T` being the desired
+  result type. You can ...
+  * ... use the formatters [shipped with this package](./src/formatters/), or
+  * ... [customize them](#customizing-formatters), or
+  * ... [write your own formatters](#writing-formatters) from scratch.
+* call `formatAdf` with the ADF object and the formatter.
+
+```ts
+import { ADFEntity, formatAdf, markdownFormatter } from '../src';
+
+const adf : ADFEntity = { /* see full representation below */ }
+const markdown = renderAdf(adf, markdownFormatter)
+```
+
+The example above will produce the following markdown given the ADF below.
+<details>
+<summary>ADF</summary>
+
+```json
+{
+    "version": 1,
+    "type": "doc",
+    "content": [
+      {
+        "type": "heading",
+        "attrs": {
+          "level": 1
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "ADF Test"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": {
+          "level": 2
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Text"
+          }
+        ]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "Text "
+          },
+          {
+            "type": "text",
+            "text": "with",
+            "marks": [
+              {
+                "type": "strong"
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "text": " "
+          },
+          {
+            "type": "text",
+            "text": "markup",
+            "marks": [
+              {
+                "type": "em"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": {
+          "level": 2
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Lists"
+          }
+        ]
+      },
+      {
+        "type": "bulletList",
+        "content": [
+          {
+            "type": "listItem",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "un-"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listItem",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "ordered"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listItem",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "list"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "orderedList",
+        "content": [
+          {
+            "type": "listItem",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "numbered"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listItem",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "list"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": {
+          "level": 2
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Links"
+          }
+        ]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "https://xkcd.com",
+            "marks": [
+              {
+                "type": "link",
+                "attrs": {
+                  "href": "https://xkcd.com"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": {
+          "level": 2
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Tables"
+          }
+        ]
+      },
+      {
+        "type": "table",
+        "attrs": {
+          "isNumberColumnEnabled": false,
+          "layout": "default",
+          "localId": "31672348-8738-4209-9135-a0c9d61c9828"
+        },
+        "content": [
+          {
+            "type": "tableRow",
+            "content": [
+              {
+                "type": "tableHeader",
+                "attrs": {},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "I",
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "tableHeader",
+                "attrs": {},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "hate",
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "tableRow",
+            "content": [
+              {
+                "type": "tableCell",
+                "attrs": {},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "tables"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "tableCell",
+                "attrs": {},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "in"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "tableRow",
+            "content": [
+              {
+                "type": "tableCell",
+                "attrs": {},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "markdown"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "tableCell",
+                "attrs": {},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "a lot"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": {
+          "level": 2
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Code"
+          }
+        ]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {
+            "type": "text",
+            "text": "Inline "
+          },
+          {
+            "type": "text",
+            "text": "code",
+            "marks": [
+              {
+                "type": "code"
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "text": " and"
+          }
+        ]
+      },
+      {
+        "type": "codeBlock",
+        "attrs": {
+          "language": "typescript"
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "// a code block\n(code) => 'blocks'"
+          }
+        ]
+      }
+    ]
+  }
+```
+</details>
+
+<details>
+<summary>Markdown source</summary>
+
+~~~md
+# ADF Test
+
+
+## Text
+
+Text **with** *markup*
+
+## Lists
+
+
+- un-
+- ordered
+- list
+
+1. numbered
+1. list
+
+## Links
+
+[https://xkcd.com](https://xkcd.com)
+
+## Tables
+
+<table>
+<tr>
+  <th>I
+  <th>hate
+<tr>
+  <td>tables
+  <td>in
+<tr>
+  <td>markdown
+  <td>a lot
+</table>
+
+## Code
+
+Inline `code` and
+
+```typescript
+// a code block
+(code) => 'blocks'
+```
+~~~
+
+</details>
+
+<details>
+<summary>Markdown rendered</summary>
+
+# ADF Test
+
+
+## Text
+
+Text **with** *markup*
+
+## Lists
+
+
+- un-
+- ordered
+- list
+
+1. numbered
+1. list
+
+## Links
+
+[https://xkcd.com](https://xkcd.com)
+
+## Tables
+
+<table>
+<tr>
+  <th>I
+  <th>hate
+<tr>
+  <td>tables
+  <td>in
+<tr>
+  <td>markdown
+  <td>a lot
+</table>
+
+## Code
+
+Inline `code` and
+
+```typescript
+// a code block
+(code) => 'blocks'
+```
+</details>
+
 ### 📦 Installation
 
-### 👩🏾‍🎨 Writing formatters
+### 👩🏾‍🎨 <a name="writing-formatters"></a>Writing formatters
 
 A `formatter` provides callbacks for each (or a subset of) the
 node types in the document. Optionally it specifies callbacks that handle markup
@@ -85,9 +564,38 @@ const formatter: Formatter<string> = {
 }); 
 ```
 
+#### Customizing formatters
+
+To customize one of [the stock formatters](./src/formatters/), spread the
+formatter into a new object and override the node/mark formatters as you see
+fit.
+
+```ts
+import { ADFEntity, formatAdf, Formatter, jsxFormatter } from '../src';
+
+const adf : ADFEntity =  { /* an ADF document */ }
+
+const myCustomizedFormatter : Formatter<JSX.Element | string>= {
+  // Use stock formatter, but ...
+  ...jsxFormatter,
+  nodes: {
+    ...jsxFormatter.nodes,
+    // ... wrap the ADF in a <section> instead of in a <div>.
+    doc: (_node, children) => <section>{children()}</section>,
+  }
+}
+
+const result : JSX.Element | string = 
+  formatAdf(adf, myCustomizedFormatter);
+
+```
+
 ### Examples
 
-#### JSX
+For more in-depth examples please refer to [the stock formatters](./src/formatters/) and [the tests](./test/).
+
+<details>
+<summary>JSX</summary>
 
 This formatter wraps the document in a `<div>`, each paragraph in a `<p>` while
 applying a subset of possible markup properties.
@@ -111,6 +619,91 @@ const jsxFormatter: Formatter<JSX.Element> = {
 }
 ```
 
+</details>
+
+<details>
+<summary>Vue (using render functions)</summary>
+
+This formatter wraps the document in a `<div>`, each paragraph in a `<p>` and
+each text node in a `span` while applying a subset of possible markup properties.
+
+```ts
+ const f: Formatter<VNode> = {
+  default: (_e, children) => h('section',children()),
+  nodes: {
+    doc: (_node, children) => h('div', children()),
+    paragraph: (_node, children) => h('p', children()),
+    text: (node) => h('span',node.text)
+  },
+  marks: {
+    text: {
+      strong: (_mark, next) => h('b', next()),
+      underline: (_mark, next) => h('u', next()),
+      em: (_mark, next) => h('i', next()),
+      code: (_mark, next) => h('code', next()),
+      strike: (_mark, next) =>
+        h('span', { style: { textDecoration: 'line-through' } }, next()),      
+    },
+  },
+}
+   
+```
+
+</details>
+
+<details>
+<summary>Counting characters</summary>
+
+This example counts the characters of all text content. It's not the intended
+usage of formatters, but shows their flexibility nicely.
+
+Note the `default` callback: Without it, it would to nothing at it would never
+recurse into child nodes from any element including the `doc` root.
+
+```ts
+const f: Formatter<number> = {
+    default: (_e, children) =>
+      children().reduce((acc, curr) => acc + curr, 0),
+    nodes: {
+      text: (node) => node.text?.length || 0,
+    },
+    marks: {},
+  };
+```
+
+</details>
+
+<details>
+<summary>Creating document outlines</summary>
+
+This example also illustrates the flexibility but is not necessarily something
+you'd typically do.
+
+It creates an outline of the ADF by ...
+
+* ... prefixig headings with the amount of spaces matching their level to create
+   indentation
+* ... outputting text elements as strings
+* ... **EXPLICITLY** recursing only into children of `doc` and `heading`, 
+  ignoring other nodes. Note that we simply return `''` from the default
+  formatter, thus not recursing into unknown elements.
+It only recurses into children of headings
+
+```ts
+const f: Formatter<string> = {
+  default: (_node) => '', // don't recurse into unknown nodes
+  nodes: {
+    doc: (_node, children) => children().join(''),
+    heading: (node, children) => ' '.repeat(
+      parseInt(node.attrs?.level as string) - 1) + children() + '\n',
+    text: (node) => node.text || '',
+  },
+  marks: {},
+};
+```
+
+</details>
+
 ## 🔧 Development
 
 * `yarn start`: Runs compilation continuously on changes.
@@ -121,3 +714,9 @@ const jsxFormatter: Formatter<JSX.Element> = {
 * `yarn size`: Checks the resulting bundle size.
 * `yarn analyze`: Explains the bundle size.
 
+### CI
+
+* PRs are tested in a matrix build with Node 14, 16 and 18 on ubuntu, windows
+  and macos
+* Builds on `main` only build on ubuntu
+* Builds on `main` will result in publication to npmjs

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ const jsxFormatter: Formatter<JSX.Element> = {
 <summary>Vue (using render functions)</summary>
 
 This formatter wraps the document in a `<div>`, each paragraph in a `<p>` and
-each text node in a `span` while applying a subset of possible markup properties.
+each text node in a `<span>` while applying a subset of possible markup properties.
 
 ```ts
  const f: Formatter<VNode> = {
@@ -657,8 +657,7 @@ each text node in a `span` while applying a subset of possible markup properties
 This example counts the characters of all text content. It's not the intended
 usage of formatters, but shows their flexibility nicely.
 
-Note the `default` callback: Without it, it would to nothing at it would never
-recurse into child nodes from any element including the `doc` root.
+Note the `default` callback: Without it, it would do nothing as it would never recurse into child nodes from any element including the doc root.
 
 ```ts
 const f: Formatter<number> = {

--- a/test/adf.fixtures.ts
+++ b/test/adf.fixtures.ts
@@ -1030,3 +1030,199 @@ export const orderedListAdf: ADFEntity = {
     },
   ],
 };
+
+export const headings2Adf: ADFEntity = {
+  version: 1,
+  type: 'doc',
+  content: [
+    {
+      type: 'heading',
+      attrs: {
+        level: 1,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 1',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Text 1',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: {
+        level: 2,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 1.1',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'text in paras is ignored',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: {
+        level: 2,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 1.2',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'text in paras is ignored',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: {
+        level: 1,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 2',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'text in paras is ignored',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'text in paras is ignored',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: {
+        level: 1,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 3',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'text in paras is ignored',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: {
+        level: 2,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 3.1',
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'text in paras is ignored',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      attrs: {
+        level: 3,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading 3.1.1',
+        },
+      ],
+    },
+  ],
+};
+
+export const simpleMarksAdf: ADFEntity = {
+  version: 1,
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'outer ',
+          marks: [
+            {
+              type: 'strong',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: 'inner',
+          marks: [
+            {
+              type: 'strong',
+            },
+            {
+              type: 'em',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: ' outer',
+          marks: [
+            {
+              type: 'strong',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -174,4 +174,195 @@ describe(`ADF parsing`, () => {
     const result = formatAdf(simpleAdf, formatter);
     expect(result).toBe('pp');
   });
+
+  it('should recurse into all children if told so in default', () => {
+    const f: Formatter<number> = {
+      default: (_e, children) =>
+        children().reduce((acc, curr) => acc + curr, 0),
+      nodes: {
+        text: (node) => node.text?.length || 0,
+      },
+      marks: {},
+    };
+
+    expect(formatAdf(simpleAdf, f)).toEqual('Hello WorldHello ADF'.length);
+  });
+
+  it('should support producing outlines', () => {
+    const adf: ADFEntity = {
+      version: 1,
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: {
+            level: 1,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 1',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Text 1',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: {
+            level: 2,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 1.1',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text in paras is ignored',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: {
+            level: 2,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 1.2',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text in paras is ignored',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: {
+            level: 1,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 2',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text in paras is ignored',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text in paras is ignored',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: {
+            level: 1,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 3',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text in paras is ignored',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: {
+            level: 2,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 3.1',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'text in paras is ignored',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: {
+            level: 3,
+          },
+          content: [
+            {
+              type: 'text',
+              text: 'Heading 3.1.1',
+            },
+          ],
+        },
+      ],
+    };
+    const f: Formatter<string> = {
+      default: (_node) => '', // don't recurse into unknown nodes
+      nodes: {
+        doc: (_node, children) => children().join(''),
+        heading: (node, children) =>
+          ' '.repeat(parseInt(node.attrs?.level as string) - 1) +
+          children() +
+          '\n',
+        text: (node) => node.text || '',
+      },
+      marks: {},
+    };
+
+    //prettier-ignore
+    expect(formatAdf(adf, f)).toEqual(`Heading 1
+ Heading 1.1
+ Heading 1.2
+Heading 2
+Heading 3
+ Heading 3.1
+  Heading 3.1.1
+`);
+  });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,4 +1,5 @@
 import { ADFEntity, Formatter, formatAdf } from '../src';
+import { headings2Adf } from './adf.fixtures';
 
 const simpleAdf: ADFEntity = {
   version: 1,
@@ -103,48 +104,6 @@ describe(`ADF parsing`, () => {
   });
 
   it('should apply all marks', () => {
-    const adf: ADFEntity = {
-      version: 1,
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'outer ',
-              marks: [
-                {
-                  type: 'strong',
-                },
-              ],
-            },
-            {
-              type: 'text',
-              text: 'inner',
-              marks: [
-                {
-                  type: 'strong',
-                },
-                {
-                  type: 'em',
-                },
-              ],
-            },
-            {
-              type: 'text',
-              text: ' outer',
-              marks: [
-                {
-                  type: 'strong',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-
     const formatter: Formatter<string> = {
       default: (_node, children) => children().join('-'),
       nodes: {},
@@ -156,7 +115,7 @@ describe(`ADF parsing`, () => {
       },
     };
 
-    expect(formatAdf(adf, formatter)).toBe('s()-e(s())-s()');
+    expect(formatAdf(simpleMarksAdf, formatter)).toBe('s()-e(s())-s()');
   });
 
   it('can exclude sub-trees per type', () => {
@@ -189,159 +148,6 @@ describe(`ADF parsing`, () => {
   });
 
   it('should support producing outlines', () => {
-    const adf: ADFEntity = {
-      version: 1,
-      type: 'doc',
-      content: [
-        {
-          type: 'heading',
-          attrs: {
-            level: 1,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 1',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'Text 1',
-            },
-          ],
-        },
-        {
-          type: 'heading',
-          attrs: {
-            level: 2,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 1.1',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'text in paras is ignored',
-            },
-          ],
-        },
-        {
-          type: 'heading',
-          attrs: {
-            level: 2,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 1.2',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'text in paras is ignored',
-            },
-          ],
-        },
-        {
-          type: 'heading',
-          attrs: {
-            level: 1,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 2',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'text in paras is ignored',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'text in paras is ignored',
-            },
-          ],
-        },
-        {
-          type: 'heading',
-          attrs: {
-            level: 1,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 3',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'text in paras is ignored',
-            },
-          ],
-        },
-        {
-          type: 'heading',
-          attrs: {
-            level: 2,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 3.1',
-            },
-          ],
-        },
-        {
-          type: 'paragraph',
-          content: [
-            {
-              type: 'text',
-              text: 'text in paras is ignored',
-            },
-          ],
-        },
-        {
-          type: 'heading',
-          attrs: {
-            level: 3,
-          },
-          content: [
-            {
-              type: 'text',
-              text: 'Heading 3.1.1',
-            },
-          ],
-        },
-      ],
-    };
     const f: Formatter<string> = {
       default: (_node) => '', // don't recurse into unknown nodes
       nodes: {
@@ -356,7 +162,7 @@ describe(`ADF parsing`, () => {
     };
 
     //prettier-ignore
-    expect(formatAdf(adf, f)).toEqual(`Heading 1
+    expect(formatAdf(headings2Adf, f)).toEqual(`Heading 1
  Heading 1.1
  Heading 1.2
 Heading 2

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,5 +1,5 @@
 import { ADFEntity, Formatter, formatAdf } from '../src';
-import { headings2Adf } from './adf.fixtures';
+import { headings2Adf, simpleMarksAdf } from './adf.fixtures';
 
 const simpleAdf: ADFEntity = {
   version: 1,


### PR DESCRIPTION
Improve readme by
* Adding examples
* Describing usage


Here is the rendered document: https://github.com/dixahq/simple-adf-formatter/blob/chore/improve-docs/README.md