### PR TITLE
chore: change partners codeowners to frontend-io

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dixahq/partnerships
+* @dixahq/frontend-io


### PR DESCRIPTION
closes #https://github.com/dixahq/agent-interface/issues/8240